### PR TITLE
Added fixes to extend support down to linux kernel 3.18

### DIFF
--- a/file.c
+++ b/file.c
@@ -244,7 +244,11 @@ void exfat_truncate(struct inode *inode, loff_t size)
 {
 	struct super_block *sb = inode->i_sb;
 	struct exfat_sb_info *sbi = EXFAT_SB(sb);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11 ,0)
+	unsigned int blocksize = 1 << inode->i_blkbits;
+#else
 	unsigned int blocksize = i_blocksize(inode);
+#endif
 	loff_t aligned_size;
 	int err;
 

--- a/file.c
+++ b/file.c
@@ -244,11 +244,7 @@ void exfat_truncate(struct inode *inode, loff_t size)
 {
 	struct super_block *sb = inode->i_sb;
 	struct exfat_sb_info *sbi = EXFAT_SB(sb);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11 ,0)
-	unsigned int blocksize = 1 << inode->i_blkbits;
-#else
 	unsigned int blocksize = i_blocksize(inode);
-#endif
 	loff_t aligned_size;
 	int err;
 

--- a/inode.c
+++ b/inode.c
@@ -454,7 +454,7 @@ static int exfat_write_end(struct file *file, struct address_space *mapping,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 static ssize_t exfat_direct_IO(struct kiocb *iocb, struct iov_iter *iter)
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 static ssize_t exfat_direct_IO(struct kiocb *iocb, struct iov_iter *iter,
                              loff_t offset)
 #else

--- a/inode.c
+++ b/inode.c
@@ -465,7 +465,7 @@ static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb,
 	struct address_space *mapping = iocb->ki_filp->f_mapping;
 	struct inode *inode = mapping->host;
 	loff_t size = iocb->ki_pos + iov_iter_count(iter);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	int rw = iov_iter_rw(iter);
 #endif
 	ssize_t ret;

--- a/inode.c
+++ b/inode.c
@@ -16,6 +16,9 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
 #include <linux/iversion.h>
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#include <linux/aio.h>
+#endif
 #include "exfat_raw.h"
 #include "exfat_fs.h"
 
@@ -451,15 +454,20 @@ static int exfat_write_end(struct file *file, struct address_space *mapping,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 static ssize_t exfat_direct_IO(struct kiocb *iocb, struct iov_iter *iter)
-#else
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
 static ssize_t exfat_direct_IO(struct kiocb *iocb, struct iov_iter *iter,
                              loff_t offset)
+#else
+static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb,
+                             struct iov_iter *iter, loff_t offset)
 #endif
 {
 	struct address_space *mapping = iocb->ki_filp->f_mapping;
 	struct inode *inode = mapping->host;
 	loff_t size = iocb->ki_pos + iov_iter_count(iter);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
 	int rw = iov_iter_rw(iter);
+#endif
 	ssize_t ret;
 
 	if (rw == WRITE) {
@@ -482,8 +490,10 @@ static ssize_t exfat_direct_IO(struct kiocb *iocb, struct iov_iter *iter,
 	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 	ret = blockdev_direct_IO(iocb, inode, iter, exfat_get_block);
-#else
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	ret = blockdev_direct_IO(iocb, inode, iter, offset, exfat_get_block);
+#else
+	ret = blockdev_direct_IO(rw, iocb, inode, iter, offset, exfat_get_block);
 #endif
 	if (ret < 0 && (rw & WRITE))
 		exfat_write_failed(mapping, size);

--- a/misc.c
+++ b/misc.c
@@ -14,6 +14,28 @@
 #include "exfat_raw.h"
 #include "exfat_fs.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+time64_t mktime64(const unsigned int year0, const unsigned int mon0,
+		const unsigned int day, const unsigned int hour,
+		const unsigned int min, const unsigned int sec)
+{
+	unsigned int mon = mon0, year = year0;
+
+	/* 1..12 -> 11,12,1..10 */
+	if (0 >= (int) (mon -= 2)) {
+		mon += 12;	/* Puts Feb last since it has leap day */
+		year -= 1;
+	}
+
+	return ((((time64_t)
+		  (year/4 - year/100 + year/400 + 367*mon/12 + day) +
+		  year*365 - 719499
+	    )*24 + hour /* now have hours */
+	  )*60 + min /* now have minutes */
+	)*60 + sec; /* finally seconds */
+}
+#endif
+
 /*
  * exfat_fs_error reports a file system problem that might indicate fa data
  * corruption/inconsistency. Depending on 'errors' mount option the

--- a/namei.c
+++ b/namei.c
@@ -15,6 +15,13 @@
 #include "exfat_raw.h"
 #include "exfat_fs.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
+static inline bool d_really_is_positive(const struct dentry *dentry)
+{
+	return dentry->d_inode != NULL;
+}
+#endif
+
 static inline unsigned long exfat_d_version(struct dentry *dentry)
 {
 	return (unsigned long) dentry->d_fsdata;


### PR DESCRIPTION
Since this driver appears more robust than the Samsung leak, this patch allows backporting for kernels present on older Android devices.