### PR TITLE
exfat: fix build on old 32 bits system

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -119,6 +119,8 @@ void exfat_get_entry_time(struct exfat_sb_info *sbi, struct timespec *ts,
 void exfat_set_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
 		u8 *tz, __le16 *time, __le16 *date, u8 *time_cs)
 #else
+#undef EXFAT_MAX_TIMESTAMP_SECS
+#define EXFAT_MAX_TIMESTAMP_SECS 0xffffffff
 void exfat_set_entry_time(struct exfat_sb_info *sbi, struct timespec *ts,
 		u8 *tz, __le16 *time, __le16 *date, u8 *time_cs)
 #endif


### PR DESCRIPTION
For kernel less than 4.19.0, the max supported date is 2038 for 32/64 bits.

This should fix :
In file included from fs/exfat/misc.c:14:
fs/exfat/misc.c: In function 'exfat_set_entry_time':
fs/exfat/exfat_raw.h:166:37: error: overflow in conversion from 'long long int' to '__kernel_time_t' {aka 'long int'} changes value from '4354819199' to '59851903' [-Werror=overflow]
166 | #define EXFAT_MAX_TIMESTAMP_SECS 4354819199LL
| ^~~~~~~~~~~~
fs/exfat/misc.c:135:16: note: in expansion of macro 'EXFAT_MAX_TIMESTAMP_SECS'
135 | ts->tv_sec = EXFAT_MAX_TIMESTAMP_SECS;
| ^~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
scripts/Makefile.build:258: recipe for target 'fs/exfat/misc.o' failed