### PR TITLE
exfat: fix build on x86 with 4.19 kernel

### DIFF
--- a/balloc.c
+++ b/balloc.c
@@ -7,7 +7,7 @@
 #include <linux/blkdev.h>
 #include <linux/slab.h>
 #include <linux/buffer_head.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 #include <linux/sched/signal.h>
 #endif
 


### PR DESCRIPTION
Fix: #24 