### PR TITLE
exfat: add necessary header for vmalloc

### DIFF
--- a/balloc.c
+++ b/balloc.c
@@ -12,6 +12,7 @@
 #else
 #include <linux/sched.h>
 #endif
+#include <linux/vmalloc.h>
 
 #include "exfat_raw.h"
 #include "exfat_fs.h"


### PR DESCRIPTION
This fixes building on Linux 4.4.