### PR TITLE
exfat: fix ALIGN_DOWN undefined error

### DIFF
--- a/balloc.c
+++ b/balloc.c
@@ -30,6 +30,10 @@
 #error "BITS_PER_LONG not 32 or 64"
 #endif
 
+#ifndef ALIGN_DOWN
+#define ALIGN_DOWN(x, a) __ALIGN_KERNEL((x) - ((a) - 1), (a))
+#endif 
+
 /*
  *  Allocation Bitmap Management Functions
  */


### PR DESCRIPTION
```
balloc.c:200:12: error: implicit declaration of function 'ALIGN_DOWN'; did you mean 'PFN_DOWN'? [-Werror=implicit-function-declaration]
  ent_idx = ALIGN_DOWN(CLUSTER_TO_BITMAP_ENT(clu), BITS_PER_LONG);
            ^~~~~~~~~~
            PFN_DOWN
```